### PR TITLE
Conversation UX improvements

### DIFF
--- a/src/objects/DialogueWindow.js
+++ b/src/objects/DialogueWindow.js
@@ -101,6 +101,9 @@ function DialogueWindow(game, convoManager/*, ...args*/) {
   // will track the conversation file, so that save checkpoints will
   // go to the correct area in the conversation
   this.convoFile = null;
+
+  // for rendering lines character by character
+  this.charTimer = null;
 }
 
 DialogueWindow.prototype = Object.create(Phaser.Group.prototype);
@@ -190,6 +193,9 @@ DialogueWindow.prototype.displayText = function (displaysInstant) {
 
   if (displaysInstant) {
     this.dialogText.displayObject.text = this.convoManager.getCurrentText();
+    if (this.charTimer != null) {
+      this._game.time.events.remove(this.charTimer);  // stop characters from rendering one by one, if they are currently rendering
+    }
     this._onDialogTextFinished.dispatch();
     return;
   }
@@ -379,6 +385,7 @@ DialogueWindow.prototype.displayCurrentLine = function () {
     if (this._cIndex == split.length) {
       // Tell the window when we're done
       this._onDialogTextFinished.dispatch();
+      this.charTimer = null;
     } else {
       // Add the next event in the chain
       this.charTimer = this._game.time.events.add(delay, nextChar, this);

--- a/src/objects/DialogueWindow.js
+++ b/src/objects/DialogueWindow.js
@@ -367,17 +367,26 @@ DialogueWindow.prototype.displayCurrentLine = function () {
   this.dialogPanel.events.onInputDown.add(this.skipText, this);
 
   var nextChar = function () {
+    var delay = 3;
     this.dialogText.displayObject.text =
       this.dialogText.displayObject.text.concat(split[this._cIndex]);
+    if (split[this._cIndex] === ',') {
+      delay = 200;    // brief pause on commas
+    } else if (['.', '?', '!'].indexOf(split[this._cIndex]) > -1) {
+      delay = 300;    // longer pause after each sentence
+    }
     this._cIndex++;
     if (this._cIndex == split.length) {
       // Tell the window when we're done
       this._onDialogTextFinished.dispatch();
+    } else {
+      // Add the next event in the chain
+      this.charTimer = this._game.time.events.add(delay, nextChar, this);
     }
   };
 
-  //  Call the 'nextChar' function once for each word in the line (line.length)
-  this._game.time.events.repeat(charDelay, split.length, nextChar, this);
+  //  Call the 'nextChar' function and chain until it reaches the end of the line
+  this.charTimer = this._game.time.events.add(0, nextChar, this);
 
 };
 

--- a/src/states/Game.js
+++ b/src/states/Game.js
@@ -35,6 +35,7 @@ exports.init = function(game, resumeGame){
   } else { //check if old model blinks
     localStorage.clear();
     game.player = (new Player(game));
+    game.player.variables['debug'] = 'true';    // comment this out to get rid of DEBUG - SKIP TO END conversation options
     game.player.convoFile = 'prologue01';
     game.room = (new Room(game, 'shuttle'));
 

--- a/static/assets/conversations/prologue01.json
+++ b/static/assets/conversations/prologue01.json
@@ -14,7 +14,7 @@
             },
             {
                 "conditions": {
-                    "debug": "true"
+                    "vardebug": "true"
                 },
                 "target": 45,
                 "text": "DEBUG - SKIP TO END"

--- a/static/assets/conversations/prologue01.json
+++ b/static/assets/conversations/prologue01.json
@@ -13,6 +13,9 @@
                 "text": "What... where am I?"
             },
             {
+                "conditions": {
+                    "debug": "true"
+                },
                 "target": 45,
                 "text": "DEBUG - SKIP TO END"
             }

--- a/static/assets/conversations/prologue02.json
+++ b/static/assets/conversations/prologue02.json
@@ -16,7 +16,7 @@
             },
             {
                 "conditions": {
-                    "debug": "true"
+                    "vardebug": "true"
                 },
                 "target": 58,
                 "text": "DEBUG - SKIP TO END"

--- a/static/assets/conversations/prologue02.json
+++ b/static/assets/conversations/prologue02.json
@@ -15,6 +15,9 @@
                 "text": "I can't understand you!"
             },
             {
+                "conditions": {
+                    "debug": "true"
+                },
                 "target": 58,
                 "text": "DEBUG - SKIP TO END"
             }

--- a/static/assets/conversations/talvine01.json
+++ b/static/assets/conversations/talvine01.json
@@ -21,6 +21,9 @@
                 "text": "That depends. Are you the xenobiologist who's supposed to study me?"
             },
             {
+                "conditions": {
+                    "debug": "true"
+                },
                 "target": 56,
                 "text": "DEBUG - SKIP TO END"
             }

--- a/static/assets/conversations/talvine01.json
+++ b/static/assets/conversations/talvine01.json
@@ -22,7 +22,7 @@
             },
             {
                 "conditions": {
-                    "debug": "true"
+                    "vardebug": "true"
                 },
                 "target": 56,
                 "text": "DEBUG - SKIP TO END"

--- a/static/assets/conversations/valken01.json
+++ b/static/assets/conversations/valken01.json
@@ -18,7 +18,7 @@
             },
             {
                 "conditions": {
-                    "debug": "true"
+                    "vardebug": "true"
                 },
                 "target": 59,
                 "text": "DEBUG - SKIP TO END"

--- a/static/assets/conversations/valken01.json
+++ b/static/assets/conversations/valken01.json
@@ -17,6 +17,9 @@
                 "text": "You're the one who's going to analyze my brain."
             },
             {
+                "conditions": {
+                    "debug": "true"
+                },
                 "target": 59,
                 "text": "DEBUG - SKIP TO END"
             }

--- a/static/assets/conversations/vesper01.json
+++ b/static/assets/conversations/vesper01.json
@@ -18,7 +18,7 @@
             },
             {
                 "conditions": {
-                    "debug": "true"
+                    "vardebug": "true"
                 },
                 "target": 38,
                 "text": "DEBUG - SKIP TO END"

--- a/static/assets/conversations/vesper01.json
+++ b/static/assets/conversations/vesper01.json
@@ -17,6 +17,9 @@
                 "text": "Leaving now."
             },
             {
+                "conditions": {
+                    "debug": "true"
+                },
                 "target": 38,
                 "text": "DEBUG - SKIP TO END"
             }


### PR DESCRIPTION
Dialogue responses now render one by one, with a brief delay between each.

When NPC dialogue lines render character by character, they pause briefly on each punctuation character.

DEBUG - SKIP TO END conversation replies are now enabled by setting a "debug" variable on the player object to "true" in Game.js, when a New Game is begun. These conversation replies won't display if the player doesn't have this variable.

There was a bug with dialogue lines rendering improperly if a Clickable in the room was interacted with while a line was rendering, causing the dialogue window to clear and redisplay. This has been fixed.